### PR TITLE
Rewrite to use dart records instead of Tuple2, fix web floating point issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "circleci.persistedProjectSelection": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "circleci.persistedProjectSelection": []
-}

--- a/lib/converter.dart
+++ b/lib/converter.dart
@@ -1,7 +1,5 @@
 import 'dart:math';
 
-import 'package:tuple/tuple.dart';
-
 import 'flutter_flexible_polyline.dart';
 
 ///
@@ -21,8 +19,7 @@ class Converter {
   }
 
   // Returns decoded int, new index in tuple
-  static Tuple2<int, int> decodeUnsignedVarint(
-      List<String> encoded, int index) {
+  static (int, int) decodeUnsignedVarint(List<String> encoded, int index) {
     int shift = 0;
     int delta = 0;
     int value;
@@ -35,7 +32,7 @@ class Converter {
       index++;
       delta |= (value & 0x1F) << shift;
       if ((value & 0x20) == 0) {
-        return Tuple2(delta, index);
+        return (delta, index);
       } else {
         shift += 5;
       }
@@ -44,22 +41,22 @@ class Converter {
     if (shift > 0) {
       throw ArgumentError("Invalid encoding");
     }
-    return Tuple2(0, index);
+    return (0, index);
   }
 
   // Decode single coordinate (say lat|lng|z) starting at index
   // Returns decoded coordinate, new index in tuple
-  Tuple2<double, int> decodeValue(List<String> encoded, int index) {
-    final Tuple2<int, int> result = decodeUnsignedVarint(encoded, index);
+  (double, int) decodeValue(List<String> encoded, int index) {
+    final (int, int) result = decodeUnsignedVarint(encoded, index);
     double coordinate = 0;
-    int delta = result.item1;
+    int delta = result.$1;
     if ((delta & 1) != 0) {
       delta = ~delta;
     }
     delta = delta >> 1;
     lastValue += delta;
     coordinate = lastValue / multiplier;
-    return Tuple2(coordinate, result.item2);
+    return (coordinate, result.$2);
   }
 
   static String encodeUnsignedVarint(int value) {

--- a/lib/flutter_flexible_polyline.dart
+++ b/lib/flutter_flexible_polyline.dart
@@ -1,6 +1,5 @@
 import 'package:flexible_polyline_dart/converter.dart';
 import 'package:flexible_polyline_dart/latlngz.dart';
-import 'package:tuple/tuple.dart';
 
 class FlexiblePolyline {
   static const int version = 1;
@@ -148,9 +147,8 @@ class FlexiblePolyline {
   /// @return type of {@link ThirdDimension}
   static ThirdDimension getThirdDimension(List<String> encoded) {
     int index = 0;
-    Tuple2<int, int> headerResult =
-        _Decoder.decodeHeaderFromString(encoded, index);
-    final int header = headerResult.item1;
+    (int, int) headerResult = _Decoder.decodeHeaderFromString(encoded, index);
+    final int header = headerResult.$1;
     return ThirdDimension.values[(header >> 4) & 7];
   }
 }
@@ -180,9 +178,9 @@ class _Decoder {
   bool hasThirdDimension() => thirdDimension != ThirdDimension.ABSENT;
 
   void _decodeHeader() {
-    final Tuple2<int, int> headerResult = decodeHeaderFromString(split, index);
-    int header = headerResult.item1;
-    index = headerResult.item2;
+    final (int, int) headerResult = decodeHeaderFromString(split, index);
+    int header = headerResult.$1;
+    index = headerResult.$2;
     precision = header & 15; // we pick the first 3 bits only
     header = header >> 4;
 
@@ -192,36 +190,32 @@ class _Decoder {
   }
 
   // Returns polyline header, new index in tuple.
-  static Tuple2<int, int> decodeHeaderFromString(
-      List<String> encoded, int index) {
+  static (int, int) decodeHeaderFromString(List<String> encoded, int index) {
     // Decode the header version
-    final Tuple2<int, int> result =
-        Converter.decodeUnsignedVarint(encoded, index);
+    final (int, int) result = Converter.decodeUnsignedVarint(encoded, index);
 
-    if (result.item1 != FlexiblePolyline.version) {
+    if (result.$1 != FlexiblePolyline.version) {
       throw ArgumentError("Invalid format version");
     }
 
     // Decode the polyline header
-    return Converter.decodeUnsignedVarint(encoded, result.item2);
+    return Converter.decodeUnsignedVarint(encoded, result.$2);
   }
 
   LatLngZ? decodeOne() {
     if (index == encoded.length) {
       return null;
     }
-    final Tuple2<double, int> latResult =
-        latConverter.decodeValue(split, index);
-    index = latResult.item2;
-    final Tuple2<double, int> lngResult =
-        lngConverter.decodeValue(split, index);
-    index = lngResult.item2;
+    final (double, int) latResult = latConverter.decodeValue(split, index);
+    index = latResult.$2;
+    final (double, int) lngResult = lngConverter.decodeValue(split, index);
+    index = lngResult.$2;
     if (hasThirdDimension()) {
-      final Tuple2<double, int> zResult = zConverter.decodeValue(split, index);
-      index = zResult.item2;
-      return LatLngZ(latResult.item1, lngResult.item1, zResult.item1);
+      final (double, int) zResult = zConverter.decodeValue(split, index);
+      index = zResult.$2;
+      return LatLngZ(latResult.$1, lngResult.$1, zResult.$1);
     }
-    return LatLngZ(latResult.item1, lngResult.item1);
+    return LatLngZ(latResult.$1, lngResult.$1);
   }
 }
 

--- a/lib/flutter_flexible_polyline.dart
+++ b/lib/flutter_flexible_polyline.dart
@@ -147,8 +147,9 @@ class FlexiblePolyline {
   /// @return type of {@link ThirdDimension}
   static ThirdDimension getThirdDimension(List<String> encoded) {
     int index = 0;
-    (int, int) headerResult = _Decoder.decodeHeaderFromString(encoded, index);
-    final int header = headerResult.$1;
+    (BigInt, int) headerResult =
+        _Decoder.decodeHeaderFromString(encoded, index);
+    final int header = headerResult.$1.toInt();
     return ThirdDimension.values[(header >> 4) & 7];
   }
 }
@@ -178,8 +179,8 @@ class _Decoder {
   bool hasThirdDimension() => thirdDimension != ThirdDimension.ABSENT;
 
   void _decodeHeader() {
-    final (int, int) headerResult = decodeHeaderFromString(split, index);
-    int header = headerResult.$1;
+    final (BigInt, int) headerResult = decodeHeaderFromString(split, index);
+    int header = headerResult.$1.toInt();
     index = headerResult.$2;
     precision = header & 15; // we pick the first 3 bits only
     header = header >> 4;
@@ -190,11 +191,11 @@ class _Decoder {
   }
 
   // Returns polyline header, new index in tuple.
-  static (int, int) decodeHeaderFromString(List<String> encoded, int index) {
+  static (BigInt, int) decodeHeaderFromString(List<String> encoded, int index) {
     // Decode the header version
-    final (int, int) result = Converter.decodeUnsignedVarint(encoded, index);
+    final (BigInt, int) result = Converter.decodeUnsignedVarint(encoded, index);
 
-    if (result.$1 != FlexiblePolyline.version) {
+    if (result.$1.toInt() != FlexiblePolyline.version) {
       throw ArgumentError("Invalid format version");
     }
 
@@ -256,8 +257,9 @@ class _Encoder {
     final double res =
         ((thirdDimPrecision << 7) | (thirdDimensionValue << 4) | precision)
             .toDouble();
-    result += Converter.encodeUnsignedVarint(FlexiblePolyline.version);
-    result += Converter.encodeUnsignedVarint(res.toInt());
+    result +=
+        Converter.encodeUnsignedVarint(BigInt.from(FlexiblePolyline.version));
+    result += Converter.encodeUnsignedVarint(BigInt.from(res));
   }
 
   void addTuple(double lat, double lng) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flexible_polyline_dart
 description: "Flexible Polyline encoder and decoder for dart"
-version: 0.0.2
+version: 1.0.2
 homepage: https://github.com/hussainhabib2/dart_flexible_polyline
 issue_tracker: https://github.com/hussainhabib2/dart_flexible_polyline/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,16 @@
 name: flexible_polyline_dart
 description: "Flexible Polyline encoder and decoder for dart"
-version: 0.0.1
+version: 0.0.2
 homepage: https://github.com/hussainhabib2/dart_flexible_polyline
 issue_tracker: https://github.com/hussainhabib2/dart_flexible_polyline/issues
 
 environment:
-  sdk: '>=3.2.0 <4.0.0'
+  sdk: ">=3.2.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  tuple: ^2.0.2
 
 dev_dependencies:
   flutter_test:

--- a/test/flutter_flexible_polyline_test.dart
+++ b/test/flutter_flexible_polyline_test.dart
@@ -6,7 +6,6 @@ import 'package:flexible_polyline_dart/flutter_flexible_polyline.dart';
 import 'package:flexible_polyline_dart/latlngz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import "package:path/path.dart" show dirname, join;
-import 'package:tuple/tuple.dart';
 
 void main() {
   test('testInvalidCoordinates', () {
@@ -105,8 +104,8 @@ void main() {
     final encoded = "h_wqiB".split('');
     double expected = -179.98321;
     Converter conv = new Converter(5);
-    Tuple2<double, int> result = conv.decodeValue(encoded, 0);
-    expect(result.item1, expected);
+    (double, int) result = conv.decodeValue(encoded, 0);
+    expect(result.$1, expected);
   });
 
   test('testSimpleLatLngDecoding', () {

--- a/test/polyline_test.dart
+++ b/test/polyline_test.dart
@@ -6,7 +6,6 @@ import 'package:flexible_polyline_dart/flutter_flexible_polyline.dart';
 import 'package:flexible_polyline_dart/latlngz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import "package:path/path.dart" show dirname, join;
-import 'package:tuple/tuple.dart';
 
 void main() {
   test('testInvalidCoordinates', () {
@@ -105,8 +104,8 @@ void main() {
     final encoded = "h_wqiB".split('');
     double expected = -179.98321;
     Converter conv = new Converter(5);
-    Tuple2<double, int> result = conv.decodeValue(encoded, 0);
-    expect(result.item1, expected);
+    (double, int) result = conv.decodeValue(encoded, 0);
+    expect(result.$1, expected);
   });
 
   test('testSimpleLatLngDecoding', () {


### PR DESCRIPTION
When compiling for web via dart2js, the default implementation of int can't handle the necessary permission for this algorithm.

As such I rewrote the code to utilize BigInt instead. I also removed the dependency on Tuple as Dart now has a buildin replacement, Records